### PR TITLE
feat(backend): Agregar configuracion para bases de datos

### DIFF
--- a/backend/example.env
+++ b/backend/example.env
@@ -1,0 +1,6 @@
+# Ejemplo de configuracion de variables de entorno par PostgreSQL
+DATABASE_HOST=localhost
+DATABASE_PORT=5432
+DATABASE_USER=your_username
+DATABASE_PASSWORD=your_password
+DATABASE_NAME=your_database

--- a/backend/src/main/resources/application-dev.yaml
+++ b/backend/src/main/resources/application-dev.yaml
@@ -16,17 +16,3 @@ spring:
   # - Configuracion de Flyway para migraciones de base de datos (desarrollo)
   flyway:
     enabled: false
-  # - Configuracion de H2 para pruebas en memoria (desarrollo)
-  #  datasource:
-  #    url: jdbc:h2:mem:dbcms
-#    username: sa
-#    password:
-#    driver-class-name: org.h2.Driver
-#  jpa:
-#    database-platform: org.hibernate.dialect.H2Dialect
-#    hibernate:
-#      ddl-auto: update
-#  h2:
-#    console:
-#      enabled: true
-#      path: /h2-console

--- a/backend/src/main/resources/application-dev.yaml
+++ b/backend/src/main/resources/application-dev.yaml
@@ -1,0 +1,32 @@
+spring:
+  # - Configuracion de PostgreSQL como base de datos principal (desarrollo)
+  datasource:
+    url: jdbc:postgresql://${DATABASE_HOST}:${DATABASE_PORT}/${DATABASE_NAME}
+    username: ${DATABASE_USER}
+    password: ${DATABASE_PASSWORD}
+    driver-class-name: org.postgresql.Driver
+  jpa:
+    hibernate:
+      ddl-auto: update
+    properties:
+      hibernate:
+        dialect: org.hibernate.dialect.PostgreSQLDialect
+        show_sql: false
+        format_sql: false
+  # - Configuracion de Flyway para migraciones de base de datos (desarrollo)
+  flyway:
+    enabled: false
+  # - Configuracion de H2 para pruebas en memoria (desarrollo)
+  #  datasource:
+  #    url: jdbc:h2:mem:dbcms
+#    username: sa
+#    password:
+#    driver-class-name: org.h2.Driver
+#  jpa:
+#    database-platform: org.hibernate.dialect.H2Dialect
+#    hibernate:
+#      ddl-auto: update
+#  h2:
+#    console:
+#      enabled: true
+#      path: /h2-console

--- a/backend/src/main/resources/application-prod.yaml
+++ b/backend/src/main/resources/application-prod.yaml
@@ -1,0 +1,22 @@
+spring:
+  # - Configuracion de PostgreSQL como base de datos principal (desarrollo)
+  datasource:
+    url: jdbc:postgresql://${DATABASE_HOST}:${DATABASE_PORT}/${DATABASE_NAME}
+    username: ${DATABASE_USER}
+    password: ${DATABASE_PASSWORD}
+    driver-class-name: org.postgresql.Driver
+  jpa:
+    hibernate:
+      ddl-auto: validate
+    properties:
+      hibernate:
+        dialect: org.hibernate.dialect.PostgreSQLDialect
+        show_sql: false
+        format_sql: false
+  # - Configuracion de Flyway para migraciones de base de datos (produccion)
+  flyway:
+    enabled: true
+    locations: classpath:db/migration
+    baseline-on-migrate: false
+    table: flyway_schema_history
+    validate-on-migrate: true

--- a/backend/src/main/resources/application-test.yaml
+++ b/backend/src/main/resources/application-test.yaml
@@ -1,0 +1,15 @@
+spring:
+  # - Configuracion de H2 para pruebas en memoria (desarrollo)
+  datasource:
+    url: jdbc:h2:mem:dbcms
+    username: sa
+    password:
+    driver-class-name: org.h2.Driver
+  jpa:
+    database-platform: org.hibernate.dialect.H2Dialect
+    hibernate:
+      ddl-auto: update
+  h2:
+    console:
+      enabled: true
+      path: /h2-console

--- a/backend/src/main/resources/application.yaml
+++ b/backend/src/main/resources/application.yaml
@@ -1,3 +1,5 @@
 spring:
   application:
     name: cms
+  profiles:
+    active: dev


### PR DESCRIPTION
Tareas que se realizaron:

- Se agregó en application.yaml profile para usar los dos archivos application-dev.yaml y application-prod.yaml para desarrollo y producción.

- Dentro de application-dev.yaml se agregaron las siguientes configuraciones: PostgreSQL y Flyway (desactivado).

- Dentro de application-prod.yaml se agregaron las siguientes configuraciones: PostgreSQL y Flyway (activado).

- Dentro de application-test.yaml se agregó la siguiente configuración: H2 (para pruebas).