### PR TITLE
feat(backend): Implementar handlers de seguridad

### DIFF
--- a/backend/src/main/java/org/testimonials/cms/security/config/handlers/CustomAccessDeniedHandler.java
+++ b/backend/src/main/java/org/testimonials/cms/security/config/handlers/CustomAccessDeniedHandler.java
@@ -1,0 +1,37 @@
+package org.testimonials.cms.security.config.handlers;
+
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.MediaType;
+import org.springframework.security.access.AccessDeniedException;
+import org.springframework.security.web.access.AccessDeniedHandler;
+import org.springframework.stereotype.Component;
+import org.testimonials.cms.global.dto.ResponseApiError;
+import tools.jackson.databind.ObjectMapper;
+
+import java.io.IOException;
+import java.time.LocalDateTime;
+
+@Component
+@RequiredArgsConstructor
+public class CustomAccessDeniedHandler implements AccessDeniedHandler {
+
+    private final ObjectMapper objectMapper;
+
+    @Override
+    public void handle(HttpServletRequest request, HttpServletResponse response, AccessDeniedException accessDeniedException) throws IOException {
+        ResponseApiError responseApiError = new ResponseApiError(
+                accessDeniedException.getLocalizedMessage(),
+                "Access denied, you do not have permission to access this resource",
+                request.getRequestURL().toString(),
+                request.getMethod(),
+                LocalDateTime.now()
+        );
+
+        response.setContentType(MediaType.APPLICATION_JSON_VALUE);
+        response.setCharacterEncoding("UTF-8");
+        response.setStatus(HttpServletResponse.SC_FORBIDDEN);
+        response.getWriter().write(objectMapper.writeValueAsString(responseApiError));
+    }
+}

--- a/backend/src/main/java/org/testimonials/cms/security/config/handlers/CustomAuthenticationEntryPoint.java
+++ b/backend/src/main/java/org/testimonials/cms/security/config/handlers/CustomAuthenticationEntryPoint.java
@@ -1,0 +1,37 @@
+package org.testimonials.cms.security.config.handlers;
+
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.web.AuthenticationEntryPoint;
+import org.springframework.stereotype.Component;
+import org.testimonials.cms.global.dto.ResponseApiError;
+import tools.jackson.databind.ObjectMapper;
+
+import java.io.IOException;
+import java.time.LocalDateTime;
+
+@Component
+@RequiredArgsConstructor
+public class CustomAuthenticationEntryPoint implements AuthenticationEntryPoint {
+
+    private final ObjectMapper objectMapper;
+
+    @Override
+    public void commence(HttpServletRequest request, HttpServletResponse response, AuthenticationException authException) throws IOException {
+        ResponseApiError responseApiError = new ResponseApiError(
+                authException.getLocalizedMessage(),
+                "Invalid Credentials",
+                request.getRequestURL().toString(),
+                request.getMethod(),
+                LocalDateTime.now()
+        );
+        response.setContentType(MediaType.APPLICATION_JSON_VALUE);
+        response.setCharacterEncoding("UTF-8");
+        response.setStatus(HttpStatus.UNAUTHORIZED.value());
+        response.getWriter().write(objectMapper.writeValueAsString(responseApiError));
+    }
+}


### PR DESCRIPTION
## Descripción

Este PR implementa los handlers personalizados de seguridad para el manejo de errores de autenticación y autorización en la aplicación.

### Cambios
- Implementación de `CustomAuthenticationEntryPoint` para manejar errores de autenticación (401 Unauthorized)
- Implementación de `CustomAccessDeniedHandler` para manejar errores de autorización (403 Forbidden)
- Integración de los handlers en la configuración de Spring Security

### Notas
- Permite respuestas más claras y controladas ante errores de seguridad
- Mejora la consistencia en el manejo de excepciones de autenticación y acceso

closed #12 