### PR TITLE
feat(backend): Creación de endpoint /api/v1/auth/me

### DIFF
--- a/backend/src/main/java/org/testimonials/cms/security/config/SecurityConfig.java
+++ b/backend/src/main/java/org/testimonials/cms/security/config/SecurityConfig.java
@@ -16,7 +16,12 @@ import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.access.AccessDeniedHandler;
 import org.springframework.security.web.access.intercept.RequestAuthorizationContext;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+import org.springframework.web.cors.CorsConfiguration;
+import org.springframework.web.cors.CorsConfigurationSource;
+import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
 import org.testimonials.cms.security.config.filter.JwtsAuthenticationFilter;
+
+import java.util.List;
 
 @Configuration
 @EnableWebSecurity
@@ -49,5 +54,21 @@ public class SecurityConfig {
                 });
 
         return httpSecurity.build();
+    }
+
+    @Bean
+    public CorsConfigurationSource corsConfigurationSource() {
+        CorsConfiguration config = new CorsConfiguration();
+
+        config.setAllowedOrigins(List.of("http://localhost:5173"));
+        config.setAllowedMethods(List.of("GET", "POST", "PUT", "DELETE","PATCH", "HEAD", "OPTIONS","TRACE"));
+        config.setAllowedHeaders(List.of("*"));
+        config.setAllowCredentials(true);
+        config.setExposedHeaders(List.of("Set-Cookie"));
+
+        UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
+        source.registerCorsConfiguration("/**", config);
+
+        return source;
     }
 }

--- a/backend/src/main/java/org/testimonials/cms/security/config/filter/JwtsAuthenticationFilter.java
+++ b/backend/src/main/java/org/testimonials/cms/security/config/filter/JwtsAuthenticationFilter.java
@@ -3,6 +3,7 @@ package org.testimonials.cms.security.config.filter;
 import com.nimbusds.jwt.JWTClaimsSet;
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
+import jakarta.servlet.http.Cookie;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
@@ -31,7 +32,7 @@ public class JwtsAuthenticationFilter extends OncePerRequestFilter {
                                     @NonNull HttpServletResponse response,
                                     @NonNull FilterChain filterChain) throws ServletException, IOException {
 
-        String jwt = jwtService.extractJwtTokenFromRequest(request);
+        String jwt = extractJwtFromCookies(request);
 
         if (jwt == null || jwt.isBlank()) {
             filterChain.doFilter(request, response);
@@ -83,5 +84,17 @@ public class JwtsAuthenticationFilter extends OncePerRequestFilter {
         SecurityContextHolder.getContext().setAuthentication(authenticationToken);
 
         filterChain.doFilter(request, response);
+    }
+
+    private String extractJwtFromCookies(HttpServletRequest request) {
+        Cookie[] cookies = request.getCookies();
+        if (cookies != null) {
+            for (Cookie cookie : cookies) {
+                if ("jwt".equals(cookie.getName())) {
+                    return cookie.getValue();
+                }
+            }
+        }
+        return null;
     }
 }

--- a/backend/src/main/java/org/testimonials/cms/security/controller/AuthenticationController.java
+++ b/backend/src/main/java/org/testimonials/cms/security/controller/AuthenticationController.java
@@ -7,11 +7,13 @@ import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseCookie;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 import org.testimonials.cms.security.dto.AuthResponseDTO;
 import org.testimonials.cms.security.dto.LoginRequestDTO;
 import org.testimonials.cms.security.dto.OrganizationAuthResponseDTO;
 import org.testimonials.cms.security.dto.OrganizationRegisterDTO;
+import org.testimonials.cms.security.model.CustomUserPrincipal;
 import org.testimonials.cms.security.services.IAuthenticationService;
 
 @RestController
@@ -55,5 +57,10 @@ public class AuthenticationController {
         return ResponseEntity.status(HttpStatus.CREATED)
                 .header(HttpHeaders.SET_COOKIE,cookie.toString())
                 .body(authResponseDTO.organization());
+    }
+
+    @GetMapping("/me")
+    public ResponseEntity<OrganizationAuthResponseDTO> me(@AuthenticationPrincipal CustomUserPrincipal userPrincipal){
+        return ResponseEntity.ok(authenticationService.me(userPrincipal));
     }
 }

--- a/backend/src/main/java/org/testimonials/cms/security/services/IAuthenticationService.java
+++ b/backend/src/main/java/org/testimonials/cms/security/services/IAuthenticationService.java
@@ -2,10 +2,14 @@ package org.testimonials.cms.security.services;
 
 import org.testimonials.cms.security.dto.AuthResponseDTO;
 import org.testimonials.cms.security.dto.LoginRequestDTO;
+import org.testimonials.cms.security.dto.OrganizationAuthResponseDTO;
 import org.testimonials.cms.security.dto.OrganizationRegisterDTO;
+import org.testimonials.cms.security.model.CustomUserPrincipal;
 
 public interface IAuthenticationService {
     AuthResponseDTO login(LoginRequestDTO loginRequestDTO);
 
     AuthResponseDTO registerOrganization(OrganizationRegisterDTO organizationRegisterDTO);
+
+    OrganizationAuthResponseDTO me(CustomUserPrincipal userPrincipal);
 }

--- a/backend/src/main/java/org/testimonials/cms/security/services/impl/AuthenticationServiceImpl.java
+++ b/backend/src/main/java/org/testimonials/cms/security/services/impl/AuthenticationServiceImpl.java
@@ -117,6 +117,24 @@ public class AuthenticationServiceImpl implements IAuthenticationService {
         return new AuthResponseDTO(orgDto,token);
     }
 
+    @Override
+    public OrganizationAuthResponseDTO me(CustomUserPrincipal principal) {
+        User user = principal.user();
+
+        Membership membership = user.getMemberships().stream()
+                .filter(m -> m.getStatus() == MembershipStatus.ACTIVE)
+                .findFirst()
+                .orElseThrow(InvalidCredentialsException::of);
+
+        return new OrganizationAuthResponseDTO(
+                membership.getOrganization().getId(),
+                membership.getOrganization().getName(),
+                membership.getOrganization().getLogo(),
+                user.getEmail(),
+                user.getName()
+        );
+    }
+
     private CustomUserPrincipal authenticateCurrentUser(LoginRequestDTO loginRequestDTO) {
         Authentication authentication = new UsernamePasswordAuthenticationToken(loginRequestDTO.email(), loginRequestDTO.password());
         Authentication authenticated = authenticationManager.authenticate(authentication);


### PR DESCRIPTION
## Descripción

Este PR implementa el endpoint `/api/v1/auth/me`, el cual permite obtener la información del usuario autenticado a partir del contexto de seguridad.

### Cambios
- Creación del endpoint `/api/v1/auth/me` en `AuthenticationController`
- Implementación de lógica en `AuthenticationService` para recuperar el usuario autenticado desde el `SecurityContext`
- Ajustes en `JwtAuthenticationFilter` para asegurar la correcta propagación del usuario autenticado
- Actualización de `SecurityConfig`, incluyendo configuración de CORS
- Integración completa con el flujo de autenticación basado en JWT

### Notas
- Permite al cliente identificar al usuario autenticado sin necesidad de reenviar credenciales
- Depende de un JWT válido enviado en la request
- Mejora la experiencia del frontend al facilitar la obtención de la sesión actual

closes #35 