### PR TITLE
Añadir puntos de acceso para el registro masivo de usuarios y tipos d…

### DIFF
--- a/backend/src/main/java/org/testimonials/cms/security/controller/AuthenticationController.java
+++ b/backend/src/main/java/org/testimonials/cms/security/controller/AuthenticationController.java
@@ -9,10 +9,7 @@ import org.springframework.http.ResponseCookie;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
-import org.testimonials.cms.security.dto.AuthResponseDTO;
-import org.testimonials.cms.security.dto.LoginRequestDTO;
-import org.testimonials.cms.security.dto.OrganizationAuthResponseDTO;
-import org.testimonials.cms.security.dto.OrganizationRegisterDTO;
+import org.testimonials.cms.security.dto.*;
 import org.testimonials.cms.security.model.CustomUserPrincipal;
 import org.testimonials.cms.security.services.IAuthenticationService;
 
@@ -62,5 +59,13 @@ public class AuthenticationController {
     @GetMapping("/me")
     public ResponseEntity<OrganizationAuthResponseDTO> me(@AuthenticationPrincipal CustomUserPrincipal userPrincipal){
         return ResponseEntity.ok(authenticationService.me(userPrincipal));
+    }
+
+    @PostMapping("/register-members")
+    public ResponseEntity<AddMembersResponseDTO> addMembers(
+            @RequestBody @Valid AddMembersRequestDTO request,
+            @AuthenticationPrincipal CustomUserPrincipal principal) {
+
+        return ResponseEntity.status(HttpStatus.CREATED).body(authenticationService.registerMembers(request,principal));
     }
 }

--- a/backend/src/main/java/org/testimonials/cms/security/controller/MembershipController.java
+++ b/backend/src/main/java/org/testimonials/cms/security/controller/MembershipController.java
@@ -1,0 +1,17 @@
+package org.testimonials.cms.security.controller;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import org.testimonials.cms.security.model.MembershipType;
+
+@RestController
+@RequestMapping("/api/v1/membership")
+public class MembershipController {
+
+    @GetMapping("/types")
+    public ResponseEntity<MembershipType[]> getMembershipTypes() {
+        return ResponseEntity.ok(MembershipType.getAssignableTypes());
+    }
+}

--- a/backend/src/main/java/org/testimonials/cms/security/dto/AddMembersRequestDTO.java
+++ b/backend/src/main/java/org/testimonials/cms/security/dto/AddMembersRequestDTO.java
@@ -1,0 +1,10 @@
+package org.testimonials.cms.security.dto;
+
+import jakarta.validation.constraints.NotEmpty;
+import java.util.List;
+
+public record AddMembersRequestDTO(
+    @NotEmpty
+    List<MemberInputDTO> members
+) {
+}

--- a/backend/src/main/java/org/testimonials/cms/security/dto/AddMembersResponseDTO.java
+++ b/backend/src/main/java/org/testimonials/cms/security/dto/AddMembersResponseDTO.java
@@ -1,0 +1,9 @@
+package org.testimonials.cms.security.dto;
+
+import java.util.List;
+
+public record AddMembersResponseDTO(
+    List<MemberResponseDTO> successful,
+    List<FailedMemberDTO> failed
+) {
+}

--- a/backend/src/main/java/org/testimonials/cms/security/dto/FailedMemberDTO.java
+++ b/backend/src/main/java/org/testimonials/cms/security/dto/FailedMemberDTO.java
@@ -1,0 +1,8 @@
+package org.testimonials.cms.security.dto;
+
+public record FailedMemberDTO(
+    int index,
+    String email,
+    String reason
+) {
+}

--- a/backend/src/main/java/org/testimonials/cms/security/dto/MemberInputDTO.java
+++ b/backend/src/main/java/org/testimonials/cms/security/dto/MemberInputDTO.java
@@ -1,0 +1,19 @@
+package org.testimonials.cms.security.dto;
+
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import org.testimonials.cms.security.model.MembershipType;
+
+public record MemberInputDTO (
+        @NotBlank
+        String name,
+        @NotBlank
+        @Email
+        String email,
+        @NotNull
+        MembershipType type,
+        @NotBlank
+        String password
+){
+}

--- a/backend/src/main/java/org/testimonials/cms/security/dto/MemberResponseDTO.java
+++ b/backend/src/main/java/org/testimonials/cms/security/dto/MemberResponseDTO.java
@@ -1,0 +1,15 @@
+package org.testimonials.cms.security.dto;
+
+import org.testimonials.cms.security.model.MembershipStatus;
+import org.testimonials.cms.security.model.MembershipType;
+
+import java.util.UUID;
+
+public record MemberResponseDTO(
+    UUID userId,
+    String name,
+    String email,
+    MembershipType type,
+    MembershipStatus status
+) {
+}

--- a/backend/src/main/java/org/testimonials/cms/security/model/MembershipType.java
+++ b/backend/src/main/java/org/testimonials/cms/security/model/MembershipType.java
@@ -1,7 +1,15 @@
 package org.testimonials.cms.security.model;
 
+import java.util.Arrays;
+
 public enum MembershipType {
     OWNER,
     ADMIN,
-    STAFF
+    STAFF;
+
+    public static MembershipType[] getAssignableTypes() {
+        return Arrays.stream(values())
+                .filter(type -> type != OWNER)
+                .toArray(MembershipType[]::new);
+    }
 }

--- a/backend/src/main/java/org/testimonials/cms/security/services/IAuthenticationService.java
+++ b/backend/src/main/java/org/testimonials/cms/security/services/IAuthenticationService.java
@@ -1,9 +1,6 @@
 package org.testimonials.cms.security.services;
 
-import org.testimonials.cms.security.dto.AuthResponseDTO;
-import org.testimonials.cms.security.dto.LoginRequestDTO;
-import org.testimonials.cms.security.dto.OrganizationAuthResponseDTO;
-import org.testimonials.cms.security.dto.OrganizationRegisterDTO;
+import org.testimonials.cms.security.dto.*;
 import org.testimonials.cms.security.model.CustomUserPrincipal;
 
 public interface IAuthenticationService {
@@ -12,4 +9,6 @@ public interface IAuthenticationService {
     AuthResponseDTO registerOrganization(OrganizationRegisterDTO organizationRegisterDTO);
 
     OrganizationAuthResponseDTO me(CustomUserPrincipal userPrincipal);
+
+    AddMembersResponseDTO registerMembers(AddMembersRequestDTO membersRequestDTO, CustomUserPrincipal principal);
 }

--- a/backend/src/main/java/org/testimonials/cms/security/services/impl/AuthenticationServiceImpl.java
+++ b/backend/src/main/java/org/testimonials/cms/security/services/impl/AuthenticationServiceImpl.java
@@ -9,18 +9,13 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.testimonials.cms.organization.model.Organization;
 import org.testimonials.cms.organization.repository.OrganizationRepository;
-import org.testimonials.cms.security.dto.AuthResponseDTO;
-import org.testimonials.cms.security.dto.LoginRequestDTO;
-import org.testimonials.cms.security.dto.OrganizationAuthResponseDTO;
-import org.testimonials.cms.security.dto.OrganizationRegisterDTO;
+import org.testimonials.cms.security.dto.*;
 import org.testimonials.cms.security.exception.EmailAlreadyExistsException;
 import org.testimonials.cms.security.exception.InvalidCredentialsException;
 import org.testimonials.cms.security.model.*;
 import org.testimonials.cms.security.services.*;
 
-import java.util.HashSet;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
 
 @Service
 @RequiredArgsConstructor
@@ -135,9 +130,66 @@ public class AuthenticationServiceImpl implements IAuthenticationService {
         );
     }
 
+    @Override
+    @Transactional
+    public AddMembersResponseDTO registerMembers(AddMembersRequestDTO membersRequestDTO, CustomUserPrincipal principal) {
+        List<MemberResponseDTO> successful = new ArrayList<>();
+        List<FailedMemberDTO> failed = new ArrayList<>();
+        List<MemberInputDTO> members = membersRequestDTO.members();
+        for (int i = 0; i < members.size(); i++) {
+            MemberInputDTO memberInput = members.get(i);
+            try {
+                MemberResponseDTO result = addSingleMember(new Organization(principal.organizationId()), memberInput);
+                successful.add(result);
+            } catch (EmailAlreadyExistsException e) {
+                failed.add(new FailedMemberDTO(i, memberInput.email(), "Email already exists"));
+            } catch (IllegalArgumentException e) {
+                failed.add(new FailedMemberDTO(i, memberInput.email(), e.getMessage()));
+            } catch (Exception e) {
+                failed.add(new FailedMemberDTO(i, memberInput.email(), "Unexpected error: " + e.getMessage()));
+            }
+        }
+        return new AddMembersResponseDTO(successful, failed);
+    }
+
     private CustomUserPrincipal authenticateCurrentUser(LoginRequestDTO loginRequestDTO) {
         Authentication authentication = new UsernamePasswordAuthenticationToken(loginRequestDTO.email(), loginRequestDTO.password());
         Authentication authenticated = authenticationManager.authenticate(authentication);
         return (CustomUserPrincipal) authenticated.getPrincipal();
+    }
+
+    private MemberResponseDTO addSingleMember(Organization organization, MemberInputDTO memberInput) {
+        if (memberInput.type() == MembershipType.OWNER) {
+            throw new IllegalArgumentException("Cannot add owner members via this endpoint");
+        }
+
+        if (userService.existsByEmail(memberInput.email())) {
+            throw EmailAlreadyExistsException.of(memberInput.email());
+        }
+
+        User user = new User();
+        user.setName(memberInput.name());
+        user.setEmail(memberInput.email());
+        user.setPassword(passwordEncoder.encode(memberInput.password()));
+        User newUser = userService.createUser(user);
+
+        Role role = roleService.findRoleByName(memberInput.type().name());
+
+        Membership membership = new Membership();
+        membership.setOrganization(organization);
+        membership.setUser(newUser);
+        membership.setRoles(Set.of(role));
+        membership.setStatus(MembershipStatus.ACTIVE);
+        membership.setType(memberInput.type());
+
+        membershipService.createNewMembership(membership);
+
+        return new MemberResponseDTO(
+                newUser.getId(),
+                newUser.getName(),
+                newUser.getEmail(),
+                memberInput.type(),
+                MembershipStatus.ACTIVE
+        );
     }
 }


### PR DESCRIPTION
##  Descripción

Se agregan dos nuevos endpoints para la gestión de membresías y registro de usuarios:

* **GET `/api/v1/membership/types`**: retorna los tipos de membresía válidos disponibles en el sistema.
* **POST `/api/v1/auth/register-members`**: permite el registro masivo de miembros asociados a un usuario.

Además, se incorporan nuevos DTOs para estructurar las solicitudes y respuestas, y se actualiza la lógica de autenticación para soportar estos flujos.

closes #36 