### PR TITLE
Implementar soporte multi-tenant basado en organization_id

### DIFF
--- a/backend/src/main/java/org/testimonials/cms/product/model/Product.java
+++ b/backend/src/main/java/org/testimonials/cms/product/model/Product.java
@@ -4,6 +4,7 @@ import jakarta.persistence.*;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
+import org.hibernate.annotations.TenantId;
 import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.annotation.LastModifiedDate;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
@@ -29,8 +30,11 @@ public class Product {
     @JoinColumn(name = "created_by")
     @ManyToOne(fetch = FetchType.LAZY)
     private User createdBy;
-    @JoinColumn(name = "organization_id")
+    @TenantId
+    @Column(name = "organization_id", nullable = false)
+    private UUID organizationId;
     @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "organization_id", insertable = false, updatable = false)
     private Organization organization;
     @CreatedDate
     @Column(name = "created_at")

--- a/backend/src/main/java/org/testimonials/cms/review/model/Review.java
+++ b/backend/src/main/java/org/testimonials/cms/review/model/Review.java
@@ -4,6 +4,7 @@ import jakarta.persistence.*;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
+import org.hibernate.annotations.TenantId;
 import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.annotation.LastModifiedDate;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
@@ -36,8 +37,11 @@ public class Review {
     @JoinColumn(name = "reviewer_id")
     @ManyToOne(fetch = FetchType.LAZY)
     private User reviewer;
-    @JoinColumn(name = "organization_id")
+    @TenantId
+    @Column(name = "organization_id", nullable = false)
+    private UUID organizationId;
     @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "organization_id", insertable = false, updatable = false)
     private Organization organization;
     @CreatedDate
     @Column(name = "created_at")

--- a/backend/src/main/java/org/testimonials/cms/security/config/hibernate/HibernateMultiTenantConfig.java
+++ b/backend/src/main/java/org/testimonials/cms/security/config/hibernate/HibernateMultiTenantConfig.java
@@ -1,0 +1,19 @@
+package org.testimonials.cms.security.config.hibernate;
+
+import org.springframework.boot.hibernate.autoconfigure.HibernatePropertiesCustomizer;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class HibernateMultiTenantConfig {
+
+    @Bean
+    public HibernatePropertiesCustomizer hibernatePropertiesCustomizer(
+            TenantIdentifierResolver tenantIdentifierResolver) {
+
+        return properties -> {
+            properties.put("hibernate.multiTenancy", "DISCRIMINATOR");
+            properties.put("hibernate.tenant_identifier_resolver", tenantIdentifierResolver);
+        };
+    }
+}

--- a/backend/src/main/java/org/testimonials/cms/security/config/hibernate/TenantIdentifierResolver.java
+++ b/backend/src/main/java/org/testimonials/cms/security/config/hibernate/TenantIdentifierResolver.java
@@ -1,0 +1,29 @@
+package org.testimonials.cms.security.config.hibernate;
+
+import org.hibernate.context.spi.CurrentTenantIdentifierResolver;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Component;
+import org.testimonials.cms.security.model.CustomUserPrincipal;
+
+import java.util.UUID;
+
+@Component
+public class TenantIdentifierResolver implements CurrentTenantIdentifierResolver<UUID> {
+
+    private static final UUID DEFAULT_TENANT = UUID.fromString("00000000-0000-0000-0000-000000000000");
+
+    @Override
+    public UUID resolveCurrentTenantIdentifier() {
+        var auth = SecurityContextHolder.getContext().getAuthentication();
+
+        if (auth != null && auth.getPrincipal() instanceof CustomUserPrincipal principal) {
+            return principal.organizationId();
+        }
+        return DEFAULT_TENANT;
+    }
+
+    @Override
+    public boolean validateExistingCurrentSessions() {
+        return true;
+    }
+}

--- a/backend/src/main/java/org/testimonials/cms/testimonial/model/Testimonial.java
+++ b/backend/src/main/java/org/testimonials/cms/testimonial/model/Testimonial.java
@@ -4,6 +4,7 @@ import jakarta.persistence.*;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
+import org.hibernate.annotations.TenantId;
 import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.annotation.LastModifiedDate;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
@@ -31,8 +32,11 @@ public class Testimonial {
     private TestimonialStatus status;
     @OneToMany(mappedBy = "testimonial", fetch = FetchType.LAZY, cascade = CascadeType.PERSIST)
     private List<Review> reviews;
-    @JoinColumn(name = "organization_id")
+    @TenantId
+    @Column(name = "organization_id", nullable = false)
+    private UUID organizationId;
     @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "organization_id", insertable = false, updatable = false)
     private Organization organization;
     @JoinColumn(name = "visitor_id")
     @ManyToOne(fetch = FetchType.LAZY)

--- a/backend/src/main/java/org/testimonials/cms/visitor/model/Visitor.java
+++ b/backend/src/main/java/org/testimonials/cms/visitor/model/Visitor.java
@@ -9,6 +9,7 @@ import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 import org.testimonials.cms.testimonial.model.Testimonial;
 
 import java.time.LocalDateTime;
+import java.util.List;
 import java.util.UUID;
 
 @Entity(name = "Visitor")
@@ -24,7 +25,7 @@ public class Visitor {
     private String name;
     private String email;
     @OneToMany(mappedBy = "visitor", fetch = FetchType.LAZY, cascade = CascadeType.PERSIST)
-    private java.util.List<Testimonial> testimonials;
+    private List<Testimonial> testimonials;
     @CreatedDate
     @Column(name = "created_at")
     private LocalDateTime createdAt;


### PR DESCRIPTION
## Soporte multi-tenant con columna discriminadora (organization_id)

### Resumen
Se implementó soporte multi-tenant utilizando la estrategia de discriminador de Hibernate basada en `organization_id`. Cada request ahora queda aislado según la organización del usuario autenticado.

### Cambios
- Se agregó `TenantIdentifierResolver` para resolver el tenant (`organization_id`) desde el `SecurityContext`
- Configuración de Hibernate con estrategia `DISCRIMINATOR`
- Actualización de entidades (`Product`, `Membership`, etc.) para incluir `organization_id`
- Uso de `@TenantId` para filtrado automático por tenant
- Relación establecida entre entidades y `Organization`
- Aislamiento de datos por organización

### Correcciones
- Eliminada lógica conflictiva de tenant en el ciclo de vida de entidades (`@PrePersist`)
- Se asegura que el tenant se obtenga correctamente desde el usuario autenticado

### Notas
- Todas las consultas ahora se filtran automáticamente por `organization_id`
- Requiere requests autenticados con `organizationId` válido en el JWT

closes #59 #60 #61