### PR TITLE
feat(backend): Creacíon de Tag y Medias

### DIFF
--- a/backend/src/main/java/org/testimonials/cms/media/controller/MediaController.java
+++ b/backend/src/main/java/org/testimonials/cms/media/controller/MediaController.java
@@ -1,0 +1,73 @@
+package org.testimonials.cms.media.controller;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.AllArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import org.testimonials.cms.media.dto.MediaResponseDTO;
+import org.testimonials.cms.media.service.IMediaService;
+import org.testimonials.cms.swagger.docs.DefaultApiResponses;
+
+import java.util.List;
+import java.util.UUID;
+
+@RestController
+@AllArgsConstructor
+@RequestMapping("/api/v1/medias")
+@Tag(name = "Medias", description = "Gestión de archivos multimedia")
+public class MediaController implements DefaultApiResponses {
+    private final IMediaService mediaService;
+
+    @GetMapping
+    @Operation(
+            summary = "Listar todos los archivos multimedia",
+            description = "Obtiene una lista de todos los archivos multimedia de la organización",
+            security = @SecurityRequirement(name = "cookieAuth"),
+            responses = {
+                    @ApiResponse(
+                            responseCode = "200",
+                            description = "Lista de archivos multimedia obtenida exitosamente",
+                            content = @Content(
+                                    mediaType = "application/json",
+                                    schema = @Schema(implementation = MediaResponseDTO.class)
+                            )
+                    )
+            }
+    )
+    public ResponseEntity<List<MediaResponseDTO>> listAllMedias() {
+        List<MediaResponseDTO> mediaResponseDTOS = mediaService.listAllMedias();
+
+        return ResponseEntity.status(HttpStatus.OK).body(mediaResponseDTOS);
+    }
+
+    @GetMapping("/{idMedia}")
+    @Operation(
+            summary = "Obtener un archivo multimedia",
+            description = "Obtiene los detalles de un archivo multimedia por su ID",
+            security = @SecurityRequirement(name = "cookieAuth"),
+            responses = {
+                    @ApiResponse(
+                            responseCode = "200",
+                            description = "Archivo multimedia obtenido exitosamente",
+                            content = @Content(
+                                    mediaType = "application/json",
+                                    schema = @Schema(implementation = MediaResponseDTO.class)
+                            )
+                    )
+            }
+    )
+    public ResponseEntity<MediaResponseDTO> listMedia(@PathVariable UUID idMedia) {
+        MediaResponseDTO mediaResponseDTO = mediaService.listMedia(idMedia);
+
+        return ResponseEntity.status(HttpStatus.OK).body(mediaResponseDTO);
+    }
+}

--- a/backend/src/main/java/org/testimonials/cms/media/dto/MediaRequestDTO.java
+++ b/backend/src/main/java/org/testimonials/cms/media/dto/MediaRequestDTO.java
@@ -1,0 +1,29 @@
+package org.testimonials.cms.media.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import org.testimonials.cms.media.enums.MediaProvider;
+import org.testimonials.cms.media.enums.MediaType;
+
+import java.util.UUID;
+
+public record MediaRequestDTO(
+        @NotNull(message = "El testimonio es requerido")
+        UUID testimonialId,
+
+        @NotNull(message = "El tipo es requerido")
+        MediaType type,
+
+        @NotNull(message = "El proveedor es requerido")
+        MediaProvider provider,
+
+        @NotBlank(message = "La URL es requerida")
+        String url,
+
+        String publicId,
+
+        String thumbnailUrl,
+
+        Integer duration
+) {
+}

--- a/backend/src/main/java/org/testimonials/cms/media/dto/MediaResponseDTO.java
+++ b/backend/src/main/java/org/testimonials/cms/media/dto/MediaResponseDTO.java
@@ -1,0 +1,36 @@
+package org.testimonials.cms.media.dto;
+
+import org.testimonials.cms.media.enums.MediaProvider;
+import org.testimonials.cms.media.enums.MediaType;
+import org.testimonials.cms.media.model.Media;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+public record MediaResponseDTO(
+        UUID id,
+        UUID testimonialId,
+        UUID organizationId,
+        MediaType type,
+        MediaProvider provider,
+        String url,
+        String publicId,
+        String thumbnailUrl,
+        Integer duration,
+        LocalDateTime createdAt
+) {
+    public MediaResponseDTO(Media media) {
+        this(
+                media.getId(),
+                media.getTestimonial() != null ? media.getTestimonial().getId() : null,
+                media.getOrganizationId(),
+                media.getType(),
+                media.getProvider(),
+                media.getUrl(),
+                media.getPublicId(),
+                media.getThumbnailUrl(),
+                media.getDuration(),
+                media.getCreatedAt()
+        );
+    }
+}

--- a/backend/src/main/java/org/testimonials/cms/media/enums/MediaProvider.java
+++ b/backend/src/main/java/org/testimonials/cms/media/enums/MediaProvider.java
@@ -1,0 +1,6 @@
+package org.testimonials.cms.media.enums;
+
+public enum MediaProvider {
+    YOUTUBE,
+    CLOUDINARY
+}

--- a/backend/src/main/java/org/testimonials/cms/media/enums/MediaType.java
+++ b/backend/src/main/java/org/testimonials/cms/media/enums/MediaType.java
@@ -1,0 +1,7 @@
+package org.testimonials.cms.media.enums;
+
+public enum MediaType {
+    IMAGE,
+    VIDEO,
+    AUDIO
+}

--- a/backend/src/main/java/org/testimonials/cms/media/exception/MediaExceptionHandler.java
+++ b/backend/src/main/java/org/testimonials/cms/media/exception/MediaExceptionHandler.java
@@ -1,0 +1,28 @@
+package org.testimonials.cms.media.exception;
+
+import jakarta.servlet.http.HttpServletRequest;
+import org.springframework.core.annotation.Order;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ProblemDetail;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+import java.net.URI;
+import java.time.LocalDateTime;
+
+@Order(11)
+@RestControllerAdvice
+public class MediaExceptionHandler {
+
+    @ExceptionHandler(MediaNotFound.class)
+    ProblemDetail handleMediaNotFoundException(MediaNotFound e, HttpServletRequest request) {
+        ProblemDetail problemDetail = ProblemDetail.forStatusAndDetail(HttpStatus.NOT_FOUND, e.getMessage());
+        problemDetail.setTitle("Media not found");
+        problemDetail.setType(URI.create("http://localhost:8080/errors/media-not-found"));
+        problemDetail.setInstance(URI.create(request.getRequestURI()));
+        problemDetail.setProperty("errorCategory", "Repository");
+        problemDetail.setProperty("errorCode", "MEDIA_NOT_FOUND");
+        problemDetail.setProperty("timestamp", LocalDateTime.now());
+        return problemDetail;
+    }
+}

--- a/backend/src/main/java/org/testimonials/cms/media/exception/MediaNotFound.java
+++ b/backend/src/main/java/org/testimonials/cms/media/exception/MediaNotFound.java
@@ -1,0 +1,13 @@
+package org.testimonials.cms.media.exception;
+
+import java.util.UUID;
+
+public class MediaNotFound extends RuntimeException {
+    public MediaNotFound(UUID id) {
+        super("Media not found with id: " + id);
+    }
+
+    public static MediaNotFound of(UUID id) {
+        return new MediaNotFound(id);
+    }
+}

--- a/backend/src/main/java/org/testimonials/cms/media/mapper/MediaMapper.java
+++ b/backend/src/main/java/org/testimonials/cms/media/mapper/MediaMapper.java
@@ -1,0 +1,23 @@
+package org.testimonials.cms.media.mapper;
+
+import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
+import org.testimonials.cms.media.dto.MediaRequestDTO;
+import org.testimonials.cms.media.dto.MediaResponseDTO;
+import org.testimonials.cms.media.model.Media;
+
+import java.util.List;
+
+@Mapper(componentModel = "spring")
+public interface MediaMapper {
+    @Mapping(target = "id", ignore = true)
+    @Mapping(target = "testimonial", ignore = true)
+    @Mapping(target = "organizationId", ignore = true)
+    @Mapping(target = "organization", ignore = true)
+    @Mapping(target = "createdAt", ignore = true)
+    Media toMedia(MediaRequestDTO mediaRequestDTO);
+
+    MediaResponseDTO toMediaDTO(Media media);
+
+    List<MediaResponseDTO> toMediaDTO(List<Media> media);
+}

--- a/backend/src/main/java/org/testimonials/cms/media/model/Media.java
+++ b/backend/src/main/java/org/testimonials/cms/media/model/Media.java
@@ -1,0 +1,63 @@
+package org.testimonials.cms.media.model;
+
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.TenantId;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+import org.testimonials.cms.media.enums.MediaProvider;
+import org.testimonials.cms.media.enums.MediaType;
+import org.testimonials.cms.organization.model.Organization;
+import org.testimonials.cms.testimonial.model.Testimonial;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+@Entity(name = "Media")
+@Table(name = "medias")
+@AllArgsConstructor
+@NoArgsConstructor
+@Data
+@EntityListeners(AuditingEntityListener.class)
+public class Media {
+    @Id
+    @GeneratedValue(strategy = GenerationType.AUTO)
+    private UUID id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "testimonial_id")
+    private Testimonial testimonial;
+
+    @TenantId
+    @Column(name = "organization_id", nullable = false)
+    private UUID organizationId;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "organization_id", insertable = false, updatable = false)
+    private Organization organization;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private MediaType type;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private MediaProvider provider;
+
+    @Column(nullable = false)
+    private String url;
+
+    @Column(name = "public_id")
+    private String publicId;
+
+    @Column(name = "thumbnail_url")
+    private String thumbnailUrl;
+
+    private Integer duration;
+
+    @CreatedDate
+    @Column(name = "created_at")
+    private LocalDateTime createdAt;
+}

--- a/backend/src/main/java/org/testimonials/cms/media/repository/IMediaRepository.java
+++ b/backend/src/main/java/org/testimonials/cms/media/repository/IMediaRepository.java
@@ -1,0 +1,13 @@
+package org.testimonials.cms.media.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+import org.testimonials.cms.media.model.Media;
+
+import java.util.List;
+import java.util.UUID;
+
+@Repository
+public interface IMediaRepository extends JpaRepository<Media, UUID> {
+    List<Media> findByTestimonialId(UUID testimonialId);
+}

--- a/backend/src/main/java/org/testimonials/cms/media/service/IMediaService.java
+++ b/backend/src/main/java/org/testimonials/cms/media/service/IMediaService.java
@@ -1,0 +1,16 @@
+package org.testimonials.cms.media.service;
+
+import org.testimonials.cms.media.dto.MediaRequestDTO;
+import org.testimonials.cms.media.dto.MediaResponseDTO;
+import org.testimonials.cms.security.model.CustomUserPrincipal;
+
+import java.util.List;
+import java.util.UUID;
+
+public interface IMediaService {
+    MediaResponseDTO createMedia(CustomUserPrincipal customUserPrincipal, MediaRequestDTO mediaRequestDTO);
+    List<MediaResponseDTO> listAllMedias();
+    MediaResponseDTO listMedia(UUID idMedia);
+    MediaResponseDTO updateMedia(UUID idMedia, MediaRequestDTO mediaRequestDTO);
+    void deleteMedia(UUID idMedia);
+}

--- a/backend/src/main/java/org/testimonials/cms/media/service/impl/MediaServiceImpl.java
+++ b/backend/src/main/java/org/testimonials/cms/media/service/impl/MediaServiceImpl.java
@@ -1,0 +1,92 @@
+package org.testimonials.cms.media.service.impl;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.testimonials.cms.cloudinary.service.CloudinaryService;
+import org.testimonials.cms.media.dto.MediaRequestDTO;
+import org.testimonials.cms.media.dto.MediaResponseDTO;
+import org.testimonials.cms.media.enums.MediaProvider;
+import org.testimonials.cms.media.exception.MediaNotFound;
+import org.testimonials.cms.media.mapper.MediaMapper;
+import org.testimonials.cms.media.model.Media;
+import org.testimonials.cms.media.repository.IMediaRepository;
+import org.testimonials.cms.media.service.IMediaService;
+import org.testimonials.cms.security.model.CustomUserPrincipal;
+import org.testimonials.cms.testimonial.exception.TestimonialNotFound;
+import org.testimonials.cms.testimonial.model.Testimonial;
+import org.testimonials.cms.testimonial.repository.ITestimonialRepository;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.UUID;
+
+@Service
+@RequiredArgsConstructor
+public class MediaServiceImpl implements IMediaService {
+    private final IMediaRepository mediaRepository;
+    private final MediaMapper mediaMapper;
+    private final CloudinaryService cloudinaryService;
+    private final ITestimonialRepository testimonialRepository;
+
+    @Override
+    @Transactional
+    public MediaResponseDTO createMedia(CustomUserPrincipal customUserPrincipal, MediaRequestDTO mediaRequestDTO) {
+        Testimonial testimonial = testimonialRepository.findById(mediaRequestDTO.testimonialId())
+                .orElseThrow(() -> TestimonialNotFound.of(mediaRequestDTO.testimonialId()));
+
+        Media media = mediaMapper.toMedia(mediaRequestDTO);
+        media.setTestimonial(testimonial);
+        media.setOrganizationId(customUserPrincipal.organizationId());
+
+        Media newMedia = mediaRepository.save(media);
+        return mediaMapper.toMediaDTO(newMedia);
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public List<MediaResponseDTO> listAllMedias() {
+        return mediaMapper.toMediaDTO(mediaRepository.findAll());
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public MediaResponseDTO listMedia(UUID idMedia) {
+        return mediaRepository.findById(idMedia)
+                .map(mediaMapper::toMediaDTO)
+                .orElseThrow(() -> MediaNotFound.of(idMedia));
+    }
+
+    @Override
+    @Transactional
+    public MediaResponseDTO updateMedia(UUID idMedia, MediaRequestDTO mediaRequestDTO) {
+        Media media = mediaRepository.findById(idMedia)
+                .orElseThrow(() -> MediaNotFound.of(idMedia));
+
+        if (mediaRequestDTO.type() != null) media.setType(mediaRequestDTO.type());
+        if (mediaRequestDTO.provider() != null) media.setProvider(mediaRequestDTO.provider());
+        if (mediaRequestDTO.url() != null) media.setUrl(mediaRequestDTO.url());
+        if (mediaRequestDTO.thumbnailUrl() != null) media.setThumbnailUrl(mediaRequestDTO.thumbnailUrl());
+        if (mediaRequestDTO.duration() != null) media.setDuration(mediaRequestDTO.duration());
+
+        Media updatedMedia = mediaRepository.save(media);
+        return mediaMapper.toMediaDTO(updatedMedia);
+    }
+
+    @Override
+    @Transactional
+    public void deleteMedia(UUID idMedia) {
+        Media media = mediaRepository.findById(idMedia)
+                .orElseThrow(() -> MediaNotFound.of(idMedia));
+
+        if (media.getProvider() == MediaProvider.CLOUDINARY && media.getPublicId() != null) {
+            try {
+                cloudinaryService.deleteFile(media.getPublicId());
+            } catch (IOException e) {
+                throw new RuntimeException("Error al eliminar el archivo de Cloudinary: " + idMedia);
+            }
+        }
+
+        mediaRepository.deleteById(idMedia);
+    }
+}

--- a/backend/src/main/java/org/testimonials/cms/tag/controller/TagController.java
+++ b/backend/src/main/java/org/testimonials/cms/tag/controller/TagController.java
@@ -1,0 +1,140 @@
+package org.testimonials.cms.tag.controller;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import lombok.AllArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+import org.testimonials.cms.security.model.CustomUserPrincipal;
+import org.testimonials.cms.swagger.docs.DefaultApiResponses;
+import org.testimonials.cms.tag.dto.TagRequestDTO;
+import org.testimonials.cms.tag.dto.TagResponseDTO;
+import org.testimonials.cms.tag.service.ITagService;
+
+import java.util.List;
+import java.util.UUID;
+
+@RestController
+@AllArgsConstructor
+@RequestMapping("/api/v1/tags")
+@Tag(name = "Tags", description = "Gestión de etiquetas")
+public class TagController implements DefaultApiResponses {
+    private final ITagService tagService;
+
+    @PostMapping("/register")
+    @Operation(
+            summary = "Crear etiqueta",
+            description = "Crea una nueva etiqueta asociada a la organización del usuario autenticado",
+            security = @SecurityRequirement(name = "cookieAuth"),
+            responses = {
+                    @ApiResponse(
+                            responseCode = "201",
+                            description = "Etiqueta creada exitosamente",
+                            content = @Content(
+                                    mediaType = "application/json",
+                                    schema = @Schema(implementation = TagResponseDTO.class)
+                            )
+                    )
+            }
+    )
+    public ResponseEntity<TagResponseDTO> createTag(
+            @AuthenticationPrincipal CustomUserPrincipal customUserPrincipal,
+            @RequestBody @Valid TagRequestDTO tagRequestDTO) {
+        TagResponseDTO tagResponseDTO = tagService.createTag(customUserPrincipal, tagRequestDTO);
+
+        return ResponseEntity.status(HttpStatus.CREATED).body(tagResponseDTO);
+    }
+
+    @GetMapping
+    @Operation(
+            summary = "Listar todas las etiquetas",
+            description = "Obtiene una lista de todas las etiquetas",
+            security = @SecurityRequirement(name = "cookieAuth"),
+            responses = {
+                    @ApiResponse(
+                            responseCode = "200",
+                            description = "Lista de etiquetas obtenida exitosamente",
+                            content = @Content(
+                                    mediaType = "application/json",
+                                    schema = @Schema(implementation = TagResponseDTO.class)
+                            )
+                    )
+            }
+    )
+    public ResponseEntity<List<TagResponseDTO>> listAllTags() {
+        List<TagResponseDTO> tagResponseDTOS = tagService.listAllTags();
+
+        return ResponseEntity.status(HttpStatus.OK).body(tagResponseDTOS);
+    }
+
+    @GetMapping("/{idTag}")
+    @Operation(
+            summary = "Obtener una etiqueta",
+            description = "Obtiene los detalles de una etiqueta por su ID",
+            security = @SecurityRequirement(name = "cookieAuth"),
+            responses = {
+                    @ApiResponse(
+                            responseCode = "200",
+                            description = "Etiqueta obtenida exitosamente",
+                            content = @Content(
+                                    mediaType = "application/json",
+                                    schema = @Schema(implementation = TagResponseDTO.class)
+                            )
+                    )
+            }
+    )
+    public ResponseEntity<TagResponseDTO> listTag(@PathVariable UUID idTag) {
+        TagResponseDTO tagResponseDTO = tagService.listTag(idTag);
+
+        return ResponseEntity.status(HttpStatus.OK).body(tagResponseDTO);
+    }
+
+    @PutMapping("/{idTag}")
+    @Operation(
+            summary = "Actualizar una etiqueta",
+            description = "Actualiza los datos de una etiqueta existente",
+            security = @SecurityRequirement(name = "cookieAuth"),
+            responses = {
+                    @ApiResponse(
+                            responseCode = "200",
+                            description = "Etiqueta actualizada exitosamente",
+                            content = @Content(
+                                    mediaType = "application/json",
+                                    schema = @Schema(implementation = TagResponseDTO.class)
+                            )
+                    )
+            }
+    )
+    public ResponseEntity<TagResponseDTO> updateTag(
+            @PathVariable UUID idTag,
+            @RequestBody @Valid TagRequestDTO tagRequestDTO) {
+        TagResponseDTO tagResponseDTO = tagService.updateTag(idTag, tagRequestDTO);
+
+        return ResponseEntity.status(HttpStatus.OK).body(tagResponseDTO);
+    }
+
+    @DeleteMapping("/{idTag}")
+    @Operation(
+            summary = "Eliminar una etiqueta",
+            description = "Elimina una etiqueta por su ID",
+            security = @SecurityRequirement(name = "cookieAuth"),
+            responses = {
+                    @ApiResponse(
+                            responseCode = "204",
+                            description = "Etiqueta eliminada exitosamente"
+                    )
+            }
+    )
+    public ResponseEntity<Void> deleteTag(@PathVariable UUID idTag) {
+        tagService.deleteTag(idTag);
+
+        return ResponseEntity.status(HttpStatus.NO_CONTENT).build();
+    }
+}

--- a/backend/src/main/java/org/testimonials/cms/tag/dto/TagRequestDTO.java
+++ b/backend/src/main/java/org/testimonials/cms/tag/dto/TagRequestDTO.java
@@ -1,0 +1,9 @@
+package org.testimonials.cms.tag.dto;
+
+import jakarta.validation.constraints.NotBlank;
+
+public record TagRequestDTO(
+        @NotBlank(message = "El nombre es requerido")
+        String name
+) {
+}

--- a/backend/src/main/java/org/testimonials/cms/tag/dto/TagResponseDTO.java
+++ b/backend/src/main/java/org/testimonials/cms/tag/dto/TagResponseDTO.java
@@ -1,0 +1,18 @@
+package org.testimonials.cms.tag.dto;
+
+import org.testimonials.cms.tag.model.Tag;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+public record TagResponseDTO(
+        UUID id,
+        String name,
+        UUID organizationId,
+        LocalDateTime createdAt,
+        LocalDateTime updatedAt
+) {
+    public TagResponseDTO(Tag tag) {
+        this(tag.getId(), tag.getName(), tag.getOrganizationId(), tag.getCreatedAt(), tag.getUpdatedAt());
+    }
+}

--- a/backend/src/main/java/org/testimonials/cms/tag/exception/TagExceptionHandler.java
+++ b/backend/src/main/java/org/testimonials/cms/tag/exception/TagExceptionHandler.java
@@ -1,0 +1,28 @@
+package org.testimonials.cms.tag.exception;
+
+import jakarta.servlet.http.HttpServletRequest;
+import org.springframework.core.annotation.Order;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ProblemDetail;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+import java.net.URI;
+import java.time.LocalDateTime;
+
+@Order(10)
+@RestControllerAdvice
+public class TagExceptionHandler {
+
+    @ExceptionHandler(TagNotFound.class)
+    ProblemDetail handleTagNotFoundException(TagNotFound e, HttpServletRequest request) {
+        ProblemDetail problemDetail = ProblemDetail.forStatusAndDetail(HttpStatus.NOT_FOUND, e.getMessage());
+        problemDetail.setTitle("Tag not found");
+        problemDetail.setType(URI.create("http://localhost:8080/errors/tag-not-found"));
+        problemDetail.setInstance(URI.create(request.getRequestURI()));
+        problemDetail.setProperty("errorCategory", "Repository");
+        problemDetail.setProperty("errorCode", "TAG_NOT_FOUND");
+        problemDetail.setProperty("timestamp", LocalDateTime.now());
+        return problemDetail;
+    }
+}

--- a/backend/src/main/java/org/testimonials/cms/tag/exception/TagNotFound.java
+++ b/backend/src/main/java/org/testimonials/cms/tag/exception/TagNotFound.java
@@ -1,0 +1,13 @@
+package org.testimonials.cms.tag.exception;
+
+import java.util.UUID;
+
+public class TagNotFound extends RuntimeException {
+    public TagNotFound(UUID id) {
+        super("Tag not found with id: " + id);
+    }
+
+    public static TagNotFound of(UUID id) {
+        return new TagNotFound(id);
+    }
+}

--- a/backend/src/main/java/org/testimonials/cms/tag/mapper/TagMapper.java
+++ b/backend/src/main/java/org/testimonials/cms/tag/mapper/TagMapper.java
@@ -1,0 +1,17 @@
+package org.testimonials.cms.tag.mapper;
+
+import org.mapstruct.Mapper;
+import org.testimonials.cms.tag.dto.TagRequestDTO;
+import org.testimonials.cms.tag.dto.TagResponseDTO;
+import org.testimonials.cms.tag.model.Tag;
+
+import java.util.List;
+
+@Mapper(componentModel = "spring")
+public interface TagMapper {
+    Tag toTag(TagRequestDTO tagRequestDTO);
+
+    TagResponseDTO toTagDTO(Tag tag);
+
+    List<TagResponseDTO> toTagDTO(List<Tag> tags);
+}

--- a/backend/src/main/java/org/testimonials/cms/tag/model/Tag.java
+++ b/backend/src/main/java/org/testimonials/cms/tag/model/Tag.java
@@ -1,0 +1,42 @@
+package org.testimonials.cms.tag.model;
+
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.TenantId;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+@Entity(name = "Tag")
+@Table(name = "tags", uniqueConstraints = {
+        @UniqueConstraint(name = "uk_tag_name_organization", columnNames = {"name", "organization_id"})
+})
+@AllArgsConstructor
+@NoArgsConstructor
+@Data
+@EntityListeners(AuditingEntityListener.class)
+public class Tag {
+    @Id
+    @GeneratedValue(strategy = GenerationType.AUTO)
+    private UUID id;
+
+    @Column(nullable = false)
+    private String name;
+
+    @TenantId
+    @Column(name = "organization_id", nullable = false)
+    private UUID organizationId;
+
+    @CreatedDate
+    @Column(name = "created_at")
+    private LocalDateTime createdAt;
+
+    @LastModifiedDate
+    @Column(name = "updated_at")
+    private LocalDateTime updatedAt;
+}

--- a/backend/src/main/java/org/testimonials/cms/tag/repository/ITagRepository.java
+++ b/backend/src/main/java/org/testimonials/cms/tag/repository/ITagRepository.java
@@ -1,0 +1,13 @@
+package org.testimonials.cms.tag.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+import org.testimonials.cms.tag.model.Tag;
+
+import java.util.Optional;
+import java.util.UUID;
+
+@Repository
+public interface ITagRepository extends JpaRepository<Tag, UUID> {
+    Optional<Tag> findByNameAndOrganizationId(String name, UUID organizationId);
+}

--- a/backend/src/main/java/org/testimonials/cms/tag/service/ITagService.java
+++ b/backend/src/main/java/org/testimonials/cms/tag/service/ITagService.java
@@ -1,0 +1,16 @@
+package org.testimonials.cms.tag.service;
+
+import org.testimonials.cms.security.model.CustomUserPrincipal;
+import org.testimonials.cms.tag.dto.TagRequestDTO;
+import org.testimonials.cms.tag.dto.TagResponseDTO;
+
+import java.util.List;
+import java.util.UUID;
+
+public interface ITagService {
+    TagResponseDTO createTag(CustomUserPrincipal customUserPrincipal, TagRequestDTO tagRequestDTO);
+    List<TagResponseDTO> listAllTags();
+    TagResponseDTO listTag(UUID idTag);
+    TagResponseDTO updateTag(UUID idTag, TagRequestDTO tagRequestDTO);
+    void deleteTag(UUID idTag);
+}

--- a/backend/src/main/java/org/testimonials/cms/tag/service/impl/TagServiceImpl.java
+++ b/backend/src/main/java/org/testimonials/cms/tag/service/impl/TagServiceImpl.java
@@ -1,0 +1,73 @@
+package org.testimonials.cms.tag.service.impl;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.testimonials.cms.security.model.CustomUserPrincipal;
+import org.testimonials.cms.tag.dto.TagRequestDTO;
+import org.testimonials.cms.tag.dto.TagResponseDTO;
+import org.testimonials.cms.tag.exception.TagNotFound;
+import org.testimonials.cms.tag.mapper.TagMapper;
+import org.testimonials.cms.tag.model.Tag;
+import org.testimonials.cms.tag.repository.ITagRepository;
+import org.testimonials.cms.tag.service.ITagService;
+
+import java.util.List;
+import java.util.UUID;
+
+@Service
+@RequiredArgsConstructor
+public class TagServiceImpl implements ITagService {
+    private final ITagRepository tagRepository;
+    private final TagMapper tagMapper;
+
+    @Override
+    @Transactional
+    public TagResponseDTO createTag(CustomUserPrincipal customUserPrincipal, TagRequestDTO tagRequestDTO) {
+        return tagRepository.findByNameAndOrganizationId(tagRequestDTO.name(), customUserPrincipal.organizationId())
+                .map(tagMapper::toTagDTO)
+                .orElseGet(() -> {
+                    Tag tag = tagMapper.toTag(tagRequestDTO);
+                    tag.setOrganizationId(customUserPrincipal.organizationId());
+                    return tagMapper.toTagDTO(tagRepository.save(tag));
+                });
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public List<TagResponseDTO> listAllTags() {
+        return tagMapper.toTagDTO(tagRepository.findAll());
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public TagResponseDTO listTag(UUID idTag) {
+        return tagRepository.findById(idTag)
+                .map(tagMapper::toTagDTO)
+                .orElseThrow(() -> TagNotFound.of(idTag));
+    }
+
+    @Override
+    @Transactional
+    public TagResponseDTO updateTag(UUID idTag, TagRequestDTO tagRequestDTO) {
+        Tag tag = tagRepository.findById(idTag)
+                .orElseThrow(() -> TagNotFound.of(idTag));
+
+        return tagRepository.findByNameAndOrganizationId(tagRequestDTO.name(), tag.getOrganizationId())
+                .filter(existing -> !existing.getId().equals(idTag))
+                .map(tagMapper::toTagDTO)
+                .orElseGet(() -> {
+                    tag.setName(tagRequestDTO.name());
+                    return tagMapper.toTagDTO(tagRepository.save(tag));
+                });
+    }
+
+    @Override
+    @Transactional
+    public void deleteTag(UUID idTag) {
+        if (tagRepository.findById(idTag).isEmpty()) {
+            throw TagNotFound.of(idTag);
+        }
+        tagRepository.deleteById(idTag);
+    }
+}


### PR DESCRIPTION
## PR: Implementación módulos Tags y Medias

---

### Resumen

Se implementaron los módulos **Tags** y **Medias** para la gestión de etiquetas y archivos multimedia de testimonios.

### Módulo Tags

| Método | Ruta | Descripción |
|--------|------|-------------|
| POST | `/api/v1/tags/register` | Crear o recuperar tag existente |
| GET | `/api/v1/tags` | Listar etiquetas |
| GET | `/api/v1/tags/{idTag}` | Obtener por ID |
| PUT | `/api/v1/tags/{idTag}` | Actualizar |
| DELETE | `/api/v1/tags/{idTag}` | Eliminar |

- Unique constraint: `(name, organization_id)`
- Comportamiento idempotente en creación
- Soporte multi-tenant

### Módulo Medias

| Método | Ruta | Descripción |
|--------|------|-------------|
| GET | `/api/v1/medias` | Listar archivos multimedia |
| GET | `/api/v1/medias/{idMedia}` | Obtener por ID |

- Enums: `MediaType` (IMAGE, VIDEO, AUDIO) y `MediaProvider` (YOUTUBE, CLOUDINARY)
- Relación ManyToOne con Testimonial
- CRUD completo disponible en servicio para integración futura
- Documentación Swagger incluida