### PR TITLE
refactor(backend): agregar usageCount, paginación y relación Product-…

### DIFF
--- a/backend/src/main/java/org/testimonials/cms/product/model/Product.java
+++ b/backend/src/main/java/org/testimonials/cms/product/model/Product.java
@@ -1,5 +1,6 @@
 package org.testimonials.cms.product.model;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import jakarta.persistence.*;
 import lombok.AllArgsConstructor;
 import lombok.Data;
@@ -10,8 +11,11 @@ import org.springframework.data.annotation.LastModifiedDate;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 import org.testimonials.cms.organization.model.Organization;
 import org.testimonials.cms.security.model.User;
+import org.testimonials.cms.tag.model.Tag;
 
 import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.UUID;
 
 @Entity(name = "Product")
@@ -38,6 +42,14 @@ public class Product {
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "organization_id", insertable = false, updatable = false)
     private Organization organization;
+    @JsonIgnore
+    @ManyToMany
+    @JoinTable(
+            name = "product_tags",
+            joinColumns = @JoinColumn(name = "product_id"),
+            inverseJoinColumns = @JoinColumn(name = "tag_id")
+    )
+    private List<Tag> tags = new ArrayList<>();
     @CreatedDate
     @Column(name = "created_at")
     private LocalDateTime createdAt;

--- a/backend/src/main/java/org/testimonials/cms/product/repository/IProductRepository.java
+++ b/backend/src/main/java/org/testimonials/cms/product/repository/IProductRepository.java
@@ -1,9 +1,19 @@
 package org.testimonials.cms.product.repository;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 import org.testimonials.cms.product.model.Product;
 
+import java.util.List;
 import java.util.UUID;
 
 public interface IProductRepository extends JpaRepository<Product, UUID> {
+    @Query("""
+    SELECT t.id, COUNT(p)
+    FROM Product p
+    JOIN p.tags t
+    WHERE p.organizationId = :organizationId
+    GROUP BY t.id
+""")
+    List<Object[]> countProductsByTagIdGrouped(UUID organizationId);
 }

--- a/backend/src/main/java/org/testimonials/cms/tag/controller/TagController.java
+++ b/backend/src/main/java/org/testimonials/cms/tag/controller/TagController.java
@@ -8,6 +8,9 @@ import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.AllArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.web.PageableDefault;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
@@ -18,7 +21,6 @@ import org.testimonials.cms.tag.dto.TagRequestDTO;
 import org.testimonials.cms.tag.dto.TagResponseDTO;
 import org.testimonials.cms.tag.service.ITagService;
 
-import java.util.List;
 import java.util.UUID;
 
 @RestController
@@ -55,7 +57,7 @@ public class TagController implements DefaultApiResponses {
     @GetMapping
     @Operation(
             summary = "Listar todas las etiquetas",
-            description = "Obtiene una lista de todas las etiquetas",
+            description = "Obtiene una lista paginada de todas las etiquetas con su usageCount",
             security = @SecurityRequirement(name = "cookieAuth"),
             responses = {
                     @ApiResponse(
@@ -68,10 +70,12 @@ public class TagController implements DefaultApiResponses {
                     )
             }
     )
-    public ResponseEntity<List<TagResponseDTO>> listAllTags() {
-        List<TagResponseDTO> tagResponseDTOS = tagService.listAllTags();
+    public ResponseEntity<Page<TagResponseDTO>> listAllTags(
+            @AuthenticationPrincipal CustomUserPrincipal customUserPrincipal,
+            @PageableDefault(size = 10) Pageable pageable) {
+        Page<TagResponseDTO> page = tagService.listAllTags(customUserPrincipal, pageable);
 
-        return ResponseEntity.status(HttpStatus.OK).body(tagResponseDTOS);
+        return ResponseEntity.status(HttpStatus.OK).body(page);
     }
 
     @GetMapping("/{idTag}")
@@ -90,8 +94,10 @@ public class TagController implements DefaultApiResponses {
                     )
             }
     )
-    public ResponseEntity<TagResponseDTO> listTag(@PathVariable UUID idTag) {
-        TagResponseDTO tagResponseDTO = tagService.listTag(idTag);
+    public ResponseEntity<TagResponseDTO> listTag(
+            @PathVariable UUID idTag,
+            @AuthenticationPrincipal CustomUserPrincipal customUserPrincipal) {
+        TagResponseDTO tagResponseDTO = tagService.listTag(idTag, customUserPrincipal.organizationId());
 
         return ResponseEntity.status(HttpStatus.OK).body(tagResponseDTO);
     }

--- a/backend/src/main/java/org/testimonials/cms/tag/mapper/TagMapper.java
+++ b/backend/src/main/java/org/testimonials/cms/tag/mapper/TagMapper.java
@@ -14,4 +14,9 @@ public interface TagMapper {
     TagResponseDTO toTagDTO(Tag tag);
 
     List<TagResponseDTO> toTagDTO(List<Tag> tags);
+
+    default TagResponseDTO toTagDTO(Tag tag, int usageCount) {
+        tag.setUsageCount(usageCount);
+        return toTagDTO(tag);
+    }
 }

--- a/backend/src/main/java/org/testimonials/cms/tag/model/Tag.java
+++ b/backend/src/main/java/org/testimonials/cms/tag/model/Tag.java
@@ -1,5 +1,6 @@
 package org.testimonials.cms.tag.model;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import jakarta.persistence.*;
 import lombok.AllArgsConstructor;
 import lombok.Data;
@@ -8,8 +9,11 @@ import org.hibernate.annotations.TenantId;
 import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.annotation.LastModifiedDate;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+import org.testimonials.cms.product.model.Product;
 
 import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.UUID;
 
 @Entity(name = "Tag")
@@ -31,6 +35,13 @@ public class Tag {
     @TenantId
     @Column(name = "organization_id", nullable = false)
     private UUID organizationId;
+
+    @JsonIgnore
+    @ManyToMany(mappedBy = "tags")
+    private List<Product> products = new ArrayList<>();
+
+    @Transient
+    private int usageCount;
 
     @CreatedDate
     @Column(name = "created_at")

--- a/backend/src/main/java/org/testimonials/cms/tag/service/ITagService.java
+++ b/backend/src/main/java/org/testimonials/cms/tag/service/ITagService.java
@@ -1,5 +1,7 @@
 package org.testimonials.cms.tag.service;
 
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.testimonials.cms.security.model.CustomUserPrincipal;
 import org.testimonials.cms.tag.dto.TagRequestDTO;
 import org.testimonials.cms.tag.dto.TagResponseDTO;
@@ -9,8 +11,8 @@ import java.util.UUID;
 
 public interface ITagService {
     TagResponseDTO createTag(CustomUserPrincipal customUserPrincipal, TagRequestDTO tagRequestDTO);
-    List<TagResponseDTO> listAllTags();
-    TagResponseDTO listTag(UUID idTag);
+    Page<TagResponseDTO> listAllTags(CustomUserPrincipal customUserPrincipal, Pageable pageable);
+    TagResponseDTO listTag(UUID idTag, UUID organizationId);
     TagResponseDTO updateTag(UUID idTag, TagRequestDTO tagRequestDTO);
     void deleteTag(UUID idTag);
 }

--- a/backend/src/main/java/org/testimonials/cms/tag/service/impl/TagServiceImpl.java
+++ b/backend/src/main/java/org/testimonials/cms/tag/service/impl/TagServiceImpl.java
@@ -1,8 +1,11 @@
 package org.testimonials.cms.tag.service.impl;
 
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.testimonials.cms.product.repository.IProductRepository;
 import org.testimonials.cms.security.model.CustomUserPrincipal;
 import org.testimonials.cms.tag.dto.TagRequestDTO;
 import org.testimonials.cms.tag.dto.TagResponseDTO;
@@ -12,39 +15,64 @@ import org.testimonials.cms.tag.model.Tag;
 import org.testimonials.cms.tag.repository.ITagRepository;
 import org.testimonials.cms.tag.service.ITagService;
 
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.UUID;
 
 @Service
 @RequiredArgsConstructor
 public class TagServiceImpl implements ITagService {
     private final ITagRepository tagRepository;
+    private final IProductRepository productRepository;
     private final TagMapper tagMapper;
+
+    private Map<UUID, Integer> buildUsageCountMap(UUID organizationId) {
+        List<Object[]> results = productRepository.countProductsByTagIdGrouped(organizationId);
+        Map<UUID, Integer> map = new HashMap<>();
+        for (Object[] row : results) {
+            map.put((UUID) row[0], ((Number) row[1]).intValue());
+        }
+        return map;
+    }
+
+    private TagResponseDTO toTagDTO(Tag tag, Map<UUID, Integer> countMap) {
+        int count = countMap.getOrDefault(tag.getId(), 0);
+        return tagMapper.toTagDTO(tag, count);
+    }
 
     @Override
     @Transactional
     public TagResponseDTO createTag(CustomUserPrincipal customUserPrincipal, TagRequestDTO tagRequestDTO) {
-        return tagRepository.findByNameAndOrganizationId(tagRequestDTO.name(), customUserPrincipal.organizationId())
-                .map(tagMapper::toTagDTO)
+        UUID orgId = customUserPrincipal.organizationId();
+        Map<UUID, Integer> countMap = buildUsageCountMap(orgId);
+
+        return tagRepository.findByNameAndOrganizationId(tagRequestDTO.name(), orgId)
+                .map(tag -> toTagDTO(tag, countMap))
                 .orElseGet(() -> {
                     Tag tag = tagMapper.toTag(tagRequestDTO);
-                    tag.setOrganizationId(customUserPrincipal.organizationId());
-                    return tagMapper.toTagDTO(tagRepository.save(tag));
+                    tag.setOrganizationId(orgId);
+                    Tag saved = tagRepository.save(tag);
+                    return toTagDTO(saved, countMap);
                 });
     }
 
     @Override
     @Transactional(readOnly = true)
-    public List<TagResponseDTO> listAllTags() {
-        return tagMapper.toTagDTO(tagRepository.findAll());
+    public Page<TagResponseDTO> listAllTags(CustomUserPrincipal customUserPrincipal, Pageable pageable) {
+        UUID orgId = customUserPrincipal.organizationId();
+        Page<Tag> tagPage = tagRepository.findAll(pageable);
+        Map<UUID, Integer> countMap = buildUsageCountMap(orgId);
+        return tagPage.map(tag -> toTagDTO(tag, countMap));
     }
 
     @Override
     @Transactional(readOnly = true)
-    public TagResponseDTO listTag(UUID idTag) {
-        return tagRepository.findById(idTag)
-                .map(tagMapper::toTagDTO)
+    public TagResponseDTO listTag(UUID idTag, UUID organizationId) {
+        Tag tag = tagRepository.findById(idTag)
                 .orElseThrow(() -> TagNotFound.of(idTag));
+        Map<UUID, Integer> countMap = buildUsageCountMap(organizationId);
+        return toTagDTO(tag, countMap);
     }
 
     @Override
@@ -52,13 +80,16 @@ public class TagServiceImpl implements ITagService {
     public TagResponseDTO updateTag(UUID idTag, TagRequestDTO tagRequestDTO) {
         Tag tag = tagRepository.findById(idTag)
                 .orElseThrow(() -> TagNotFound.of(idTag));
+        UUID orgId = tag.getOrganizationId();
+        Map<UUID, Integer> countMap = buildUsageCountMap(orgId);
 
-        return tagRepository.findByNameAndOrganizationId(tagRequestDTO.name(), tag.getOrganizationId())
+        return tagRepository.findByNameAndOrganizationId(tagRequestDTO.name(), orgId)
                 .filter(existing -> !existing.getId().equals(idTag))
-                .map(tagMapper::toTagDTO)
+                .map(t -> toTagDTO(t, countMap))
                 .orElseGet(() -> {
                     tag.setName(tagRequestDTO.name());
-                    return tagMapper.toTagDTO(tagRepository.save(tag));
+                    Tag saved = tagRepository.save(tag);
+                    return toTagDTO(saved, countMap);
                 });
     }
 


### PR DESCRIPTION
## Resumen

Se implementaron mejoras en el módulo de Tags del CMS:

- **Agregar usageCount**: Nuevo campo que muestra la cantidad de productos asociados a cada tag
- **Paginación**: Endpoint GET /api/v1/tags ahora soporta paginación con parámetros `page`, `size` y `sort`
- **Relación Product-Tags**: Se estableció relación ManyToMany entre Products y Tags
- **Tag.java**: Agregado `@ManyToMany(mappedBy = "tags")` y `@Transient usageCount`
- **Product.java**: Agregado `@ManyToMany` con `@JoinTable(name = "product_tags")`
- **TagResponseDTO.java**: Nuevo campo `int usageCount`
- **IProductRepository.java**: Nueva query nativa `countProductsByTagIdGrouped()` para obtener conteos optimizados en una sola consulta
- **TagMapper.java**: Nuevo método `toTagDTO(Tag tag, int usageCount)`
- **ITagService.java**: Actualizado `listAllTags()` para aceptar `Pageable`
- **TagServiceImpl.java**: Implementación con:
  - `buildUsageCountMap()`: Construye mapa de conteos en una sola query
  - `toTagDTO(Tag, Map)`: Asigna usageCount a cada tag
  - `listAllTags()`: Retorna `Page<TagResponseDTO>` con conteos
- **TagController.java**: Endpoint `GET /api/v1/tags` ahora acepta `Pageable` y retorna `Page<TagResponseDTO>`
